### PR TITLE
MW-383: Fixed accessing 'View Orders' page with only one right

### DIFF
--- a/src/referencedata-facility/facility.factory.js
+++ b/src/referencedata-facility/facility.factory.js
@@ -138,10 +138,8 @@
             }
 
             function getFulfillmentFacilities(userId, rightName) {
-                return facilityService.getFulfillmentFacilities({
-                    userId: userId,
-                    rightId: authorizationService.getRightByName(rightName).id
-                });
+                var right = authorizationService.getRightByName(rightName);
+                return right ? facilityService.getFulfillmentFacilities({userId: userId, rightId: right.id}) : [];
             }
 
             /**


### PR DESCRIPTION
When missing POD_MANAGE or ORDERS_VIEW right, user was not able to open View Orders page.
It was possible only if user had two rights despite the fact that only one of those two is required.