### PR TITLE
add missing message string for empty partner node list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+5.6.5 / WIMP
+============
+
+Bug fixes:
+* [OLMIS-5851](hhttps://openlmis.atlassian.net/browse/OLMIS-5851):  Added missing message string for empty partner node list when editing supervisory nodes.
+
 5.6.4 / 2020-11-17
 ==================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ============
 
 Bug fixes:
-* [OLMIS-5851](hhttps://openlmis.atlassian.net/browse/OLMIS-5851):  Added missing message string for empty partner node list when editing supervisory nodes.
+* [OLMIS-5851](https://openlmis.atlassian.net/browse/OLMIS-5851):  Added missing message string for empty partner node list when editing supervisory nodes.
 
 5.6.4 / 2020-11-17
 ==================

--- a/src/admin-supervisory-node-edit/messages_en.json
+++ b/src/admin-supervisory-node-edit/messages_en.json
@@ -21,5 +21,6 @@
     "adminSupervisoryNodeEdit.confirmChildNodeRemoval": "Do you really want to remove the child node?",
     "adminSupervisoryNodeEdit.confirmPartnerNodeRemoval": "Do you really want to remove the partner node?",
     "adminSupervisoryNodeEdit.partnerNodes": "Partner Nodes",
+    "adminSupervisoryNodeEdit.noPartnerNodes": "No partner nodes assigned",
     "adminSupervisoryNodeEdit.removePartnerNode": "Remove Partner Node"
 }


### PR DESCRIPTION
 add missing message string for empty partner node list when editing supervisory nodes