### PR TITLE
SELV3-780: add geographic zone entry to import data

### DIFF
--- a/src/admin-data-import/consts.jsx
+++ b/src/admin-data-import/consts.jsx
@@ -23,5 +23,10 @@ export const TYPE_OF_IMPORTS = [
         value: "Facility",
         name: "Facilities",
         info: "To import Facilities you need: facility.csv, supportedProgram.csv"
+    },
+    {
+        value: "GeographicZone",
+        name: "Geographic Zones",
+        info: "To import Geographic Zones you need a ZIP with a geographicZones.csv file."
     }
 ];


### PR DESCRIPTION
[SELV3-780](https://openlmis.atlassian.net/browse/SELV3-780)

Changes:
- Add `Geographic Zones` entry to the Data Import type dropdown.

[SELV3-780]: https://openlmis.atlassian.net/browse/SELV3-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ