### PR TITLE
SELV3-792: adjust the naming of the rights when a role is of the repo…

### DIFF
--- a/src/admin-role-form/right.filter.js
+++ b/src/admin-role-form/right.filter.js
@@ -41,15 +41,38 @@
         .module('admin-role-form')
         .filter('right', roleRightFilter);
 
-    roleRightFilter.$inject = ['messageService', '$filter'];
+    roleRightFilter.$inject = ['messageService', '$filter', 'ROLE_TYPES'];
 
-    function roleRightFilter(messageService, $filter) {
-        return function(rightName) {
+    function roleRightFilter(messageService, $filter, ROLE_TYPES) {
+        return function(rightName, roleType) {
             if (!rightName) {
                 return undefined;
             }
+
+            if (roleType === ROLE_TYPES.REPORTS) {
+                return createReportRightName(rightName);
+            }
+
             return messageService.get('adminRoleForm.' + $filter('camelCase')(rightName));
         };
+    }
+
+    /**
+     * @ngdoc method
+     * @methodOf admin-role-form.filter:right
+     * @name createReportRightName
+     * 
+     * @description
+     * Formats the given right name into more user-friendly string. First, it replaces all underscores. Then, it
+     * lowercases the string, splits it by spaces, capitalizes the first letter of each word, and joins them back.
+     */
+    function createReportRightName(rightName) {
+        return rightName
+            .replace(/_/g, ' ')
+            .toLowerCase()
+            .split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
     }
 
 })();

--- a/src/admin-role-form/role-form.html
+++ b/src/admin-role-form/role-form.html
@@ -12,7 +12,7 @@
         <legend>Rights</legend>
         <label ng-repeat="right in vm.rights" class="checkbox">
            <input type="checkbox" ng-model="right.checked" ng-required="vm.isNoneSelected()"/>
-           {{right.name | right}}
+           {{right.name | right:vm.type}}
         </label>
     </fieldset>
 </form>


### PR DESCRIPTION
…rts type

[SELV3-792](https://openlmis.atlassian.net/browse/SELV3-792)

Changes:
- If the role is of the `Reports` type, format the given right name into more user-friendly string.

[SELV3-792]: https://openlmis.atlassian.net/browse/SELV3-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ