### PR TITLE
MW-1449: Add Embedded UUID field to dashboard report admin form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Improvements:
   * Hide panel when user has no home facility
   * Reorder requisition and order statuses
   * Other minor layout/font improvements
+New functionality:
+* [MW-1449](https://openlmis.atlassian.net/browse/MW-1449): Added Embedded UUID field to the dashboard report admin form. For Superset reports, either URL or Embedded UUID is required; for other report types, URL remains required.
 
 5.6.18 / 2026-02-05
 ==================

--- a/src/admin-report-edit/admin-report-edit.controller.js
+++ b/src/admin-report-edit/admin-report-edit.controller.js
@@ -38,6 +38,8 @@
         vm.$onInit = onInit;
         vm.confirmEdit = confirmEdit;
         vm.validateField = validateField;
+        vm.validateSupersetFields = validateSupersetFields;
+        vm.onTypeChange = onTypeChange;
         vm.invalidFields = new Set();
 
         /**
@@ -165,12 +167,39 @@
         }
 
         function validateEditReport() {
-            var fieldsToValidate = ['name', 'url', 'category', 'type'];
+            var fieldsToValidate = ['name', 'category', 'type'];
             fieldsToValidate.forEach(function(fieldName) {
                 validateField(vm.report[fieldName], fieldName);
             });
 
+            if (vm.report.type === 'SUPERSET') {
+                if (!vm.report.url && !vm.report.embeddedUuid) {
+                    vm.invalidFields.add('supersetField');
+                } else {
+                    vm.invalidFields.delete('supersetField');
+                }
+            } else {
+                validateField(vm.report.url, 'url');
+            }
+
             return vm.invalidFields.size === 0;
+        }
+
+        function validateSupersetFields() {
+            if (vm.report.type === 'SUPERSET') {
+                if (vm.report.url || vm.report.embeddedUuid) {
+                    vm.invalidFields.delete('supersetField');
+                    vm.invalidFields.delete('url');
+                }
+            }
+        }
+
+        function onTypeChange() {
+            validateField(vm.report.type, 'type');
+            vm.invalidFields.delete('supersetField');
+            if (vm.report.type === 'SUPERSET') {
+                vm.invalidFields.delete('url');
+            }
         }
 
         function isNotEmpty(value) {

--- a/src/admin-report-edit/admin-report-edit.controller.js
+++ b/src/admin-report-edit/admin-report-edit.controller.js
@@ -98,6 +98,8 @@
 
         vm.reportsList = reportsList;
 
+        vm.REPORT_TYPES = REPORT_TYPES;
+
         function onInit() {
             vm.editMode = !!dashboardReport;
             categories.map(function(category) {
@@ -172,7 +174,7 @@
                 validateField(vm.report[fieldName], fieldName);
             });
 
-            if (vm.report.type === 'SUPERSET') {
+            if (vm.report.type === REPORT_TYPES.SUPERSET) {
                 if (!vm.report.url && !vm.report.embeddedUuid) {
                     vm.invalidFields.add('supersetField');
                 } else {
@@ -186,7 +188,7 @@
         }
 
         function validateSupersetFields() {
-            if (vm.report.type === 'SUPERSET') {
+            if (vm.report.type === REPORT_TYPES.SUPERSET) {
                 if (vm.report.url || vm.report.embeddedUuid) {
                     vm.invalidFields.delete('supersetField');
                     vm.invalidFields.delete('url');
@@ -197,7 +199,7 @@
         function onTypeChange() {
             validateField(vm.report.type, 'type');
             vm.invalidFields.delete('supersetField');
-            if (vm.report.type === 'SUPERSET') {
+            if (vm.report.type === REPORT_TYPES.SUPERSET) {
                 vm.invalidFields.delete('url');
             }
         }

--- a/src/admin-report-edit/admin-report-edit.controller.spec.js
+++ b/src/admin-report-edit/admin-report-edit.controller.spec.js
@@ -1,0 +1,356 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('ReportEditController', function() {
+
+    beforeEach(function() {
+        module('admin-report-edit');
+
+        inject(function($injector) {
+            this.$controller = $injector.get('$controller');
+            this.$rootScope = $injector.get('$rootScope');
+            this.$state = $injector.get('$state');
+            this.$q = $injector.get('$q');
+            this.confirmService = $injector.get('confirmService');
+            this.stateTrackerService = $injector.get('stateTrackerService');
+            this.loadingModalService = $injector.get('loadingModalService');
+            this.notificationService = $injector.get('notificationService');
+            this.messageService = $injector.get('messageService');
+            this.reportDashboardService = $injector.get('reportDashboardService');
+            this.REPORT_TYPES = $injector.get('REPORT_TYPES');
+            this.ReportDashboardDataBuilder = $injector.get('ReportDashboardDataBuilder');
+            this.ReportCategoryDataBuilder = $injector.get('ReportCategoryDataBuilder');
+        });
+
+        this.categories = [
+            new this.ReportCategoryDataBuilder().build(),
+            new this.ReportCategoryDataBuilder().build()
+        ];
+
+        this.dashboardReport = new this.ReportDashboardDataBuilder()
+            .withType(this.REPORT_TYPES.SUPERSET)
+            .build();
+        this.dashboardReport.category = this.categories[0];
+
+        this.reportsList = [this.dashboardReport];
+
+        this.saveDeferred = this.$q.defer();
+
+        spyOn(this.confirmService, 'confirm').andReturn(this.$q.resolve());
+        spyOn(this.stateTrackerService, 'goToPreviousState').andReturn(true);
+        spyOn(this.reportDashboardService, 'edit').andReturn(this.saveDeferred.promise);
+        spyOn(this.reportDashboardService, 'add').andReturn(this.saveDeferred.promise);
+        spyOn(this.loadingModalService, 'open').andReturn(true);
+        spyOn(this.loadingModalService, 'close').andReturn(true);
+        spyOn(this.notificationService, 'success');
+        spyOn(this.notificationService, 'error');
+        spyOn(this.$state, 'go').andReturn();
+        spyOn(this.messageService, 'get').andReturn('confirm-message');
+
+        this.initController = function(dashboardReport) {
+            this.vm = this.$controller('ReportEditController', {
+                dashboardReport: dashboardReport === undefined ? this.dashboardReport : dashboardReport,
+                categories: this.categories,
+                reportsList: this.reportsList
+            });
+            this.vm.$onInit();
+        };
+    });
+
+    describe('$onInit', function() {
+
+        beforeEach(function() {
+            this.initController();
+        });
+
+        it('should expose REPORT_TYPES constant for use in the template', function() {
+            expect(this.vm.REPORT_TYPES).toBe(this.REPORT_TYPES);
+        });
+
+        it('should set editMode to true when a dashboardReport is provided', function() {
+            expect(this.vm.editMode).toBe(true);
+        });
+
+        it('should set editMode to false when no dashboardReport is provided', function() {
+            this.initController(null);
+
+            expect(this.vm.editMode).toBe(false);
+        });
+
+        it('should expose all report types', function() {
+            expect(this.vm.types).toEqual(this.REPORT_TYPES.getTypes());
+        });
+    });
+
+    describe('validateField', function() {
+
+        beforeEach(function() {
+            this.initController();
+        });
+
+        it('should add field name to invalidFields when value is empty', function() {
+            this.vm.validateField('', 'name');
+
+            expect(this.vm.invalidFields.has('name')).toBe(true);
+        });
+
+        it('should remove field name from invalidFields when value becomes non-empty', function() {
+            this.vm.invalidFields.add('name');
+
+            this.vm.validateField('some value', 'name');
+
+            expect(this.vm.invalidFields.has('name')).toBe(false);
+        });
+    });
+
+    describe('validateSupersetFields', function() {
+
+        beforeEach(function() {
+            this.initController();
+            this.vm.report.type = this.REPORT_TYPES.SUPERSET;
+            this.vm.invalidFields.add('supersetField');
+            this.vm.invalidFields.add('url');
+        });
+
+        it('should clear supersetField and url errors when url is provided', function() {
+            this.vm.report.url = 'https://example.org/dashboard';
+            this.vm.report.embeddedUuid = undefined;
+
+            this.vm.validateSupersetFields();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+        });
+
+        it('should clear supersetField and url errors when embeddedUuid is provided', function() {
+            this.vm.report.url = undefined;
+            this.vm.report.embeddedUuid = 'abc-uuid';
+
+            this.vm.validateSupersetFields();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+        });
+
+        it('should not clear errors when both url and embeddedUuid are empty', function() {
+            this.vm.report.url = '';
+            this.vm.report.embeddedUuid = '';
+
+            this.vm.validateSupersetFields();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(true);
+            expect(this.vm.invalidFields.has('url')).toBe(true);
+        });
+
+        it('should be a no-op when type is not SUPERSET', function() {
+            this.vm.report.type = this.REPORT_TYPES.POWERBI;
+            this.vm.report.url = 'https://example.org/dashboard';
+
+            this.vm.validateSupersetFields();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(true);
+            expect(this.vm.invalidFields.has('url')).toBe(true);
+        });
+    });
+
+    describe('onTypeChange', function() {
+
+        beforeEach(function() {
+            this.initController();
+        });
+
+        it('should add type to invalidFields when type is empty', function() {
+            this.vm.report.type = '';
+
+            this.vm.onTypeChange();
+
+            expect(this.vm.invalidFields.has('type')).toBe(true);
+        });
+
+        it('should remove type from invalidFields when type is provided', function() {
+            this.vm.invalidFields.add('type');
+            this.vm.report.type = this.REPORT_TYPES.SUPERSET;
+
+            this.vm.onTypeChange();
+
+            expect(this.vm.invalidFields.has('type')).toBe(false);
+        });
+
+        it('should clear supersetField error whenever type changes', function() {
+            this.vm.invalidFields.add('supersetField');
+            this.vm.report.type = this.REPORT_TYPES.POWERBI;
+
+            this.vm.onTypeChange();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+        });
+
+        it('should clear url error when type changes to SUPERSET', function() {
+            this.vm.invalidFields.add('url');
+            this.vm.report.type = this.REPORT_TYPES.SUPERSET;
+
+            this.vm.onTypeChange();
+
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+        });
+
+        it('should not clear url error when type changes to a non-SUPERSET type', function() {
+            this.vm.invalidFields.add('url');
+            this.vm.report.type = this.REPORT_TYPES.POWERBI;
+
+            this.vm.onTypeChange();
+
+            expect(this.vm.invalidFields.has('url')).toBe(true);
+        });
+    });
+
+    describe('confirmEdit (validateEditReport)', function() {
+
+        function setReport(vm, overrides) {
+            vm.report.name = 'name' in overrides ? overrides.name : 'Report name';
+            vm.report.category = 'category' in overrides ? overrides.category : vm.report.category;
+            vm.report.type = 'type' in overrides ? overrides.type : vm.report.type;
+            vm.report.url = 'url' in overrides ? overrides.url : '';
+            vm.report.embeddedUuid = 'embeddedUuid' in overrides ? overrides.embeddedUuid : '';
+            vm.report.showOnHomePage = false;
+        }
+
+        beforeEach(function() {
+            this.initController();
+        });
+
+        it('should flag name, category and type when they are empty regardless of report type', function() {
+            setReport(this.vm, {
+                name: '',
+                category: undefined,
+                type: ''
+            });
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('name')).toBe(true);
+            expect(this.vm.invalidFields.has('category')).toBe(true);
+            expect(this.vm.invalidFields.has('type')).toBe(true);
+            expect(this.reportDashboardService.edit).not.toHaveBeenCalled();
+            expect(this.reportDashboardService.add).not.toHaveBeenCalled();
+        });
+
+        it('should require either URL or embeddedUuid when type is SUPERSET', function() {
+            setReport(this.vm, {
+                type: this.REPORT_TYPES.SUPERSET,
+                url: '',
+                embeddedUuid: ''
+            });
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(true);
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+            expect(this.reportDashboardService.edit).not.toHaveBeenCalled();
+        });
+
+        it('should pass validation for SUPERSET when only URL is provided', function() {
+            setReport(this.vm, {
+                type: this.REPORT_TYPES.SUPERSET,
+                url: 'https://example.org/dashboard',
+                embeddedUuid: ''
+            });
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+            expect(this.reportDashboardService.edit).toHaveBeenCalled();
+        });
+
+        it('should pass validation for SUPERSET when only embeddedUuid is provided', function() {
+            setReport(this.vm, {
+                type: this.REPORT_TYPES.SUPERSET,
+                url: '',
+                embeddedUuid: 'abc-uuid'
+            });
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+            expect(this.reportDashboardService.edit).toHaveBeenCalled();
+        });
+
+        it('should clear supersetField error when both URL and embeddedUuid are provided', function() {
+            setReport(this.vm, {
+                type: this.REPORT_TYPES.SUPERSET,
+                url: 'https://example.org/dashboard',
+                embeddedUuid: 'abc-uuid'
+            });
+            this.vm.invalidFields.add('supersetField');
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+        });
+
+        it('should require URL when type is not SUPERSET', function() {
+            setReport(this.vm, {
+                type: this.REPORT_TYPES.POWERBI,
+                url: '',
+                embeddedUuid: 'abc-uuid'
+            });
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('url')).toBe(true);
+            expect(this.vm.invalidFields.has('supersetField')).toBe(false);
+            expect(this.reportDashboardService.edit).not.toHaveBeenCalled();
+        });
+
+        it('should pass validation for non-SUPERSET when URL is provided', function() {
+            setReport(this.vm, {
+                type: this.REPORT_TYPES.POWERBI,
+                url: 'https://example.org/dashboard'
+            });
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.vm.invalidFields.has('url')).toBe(false);
+            expect(this.reportDashboardService.edit).toHaveBeenCalled();
+        });
+
+        it('should call add when there is no existing dashboardReport', function() {
+            this.initController(null);
+            this.vm.report = {
+                name: 'New report',
+                category: this.categories[0],
+                type: this.REPORT_TYPES.SUPERSET,
+                url: 'https://example.org/dashboard',
+                embeddedUuid: '',
+                showOnHomePage: false
+            };
+
+            this.vm.confirmEdit();
+            this.$rootScope.$apply();
+
+            expect(this.reportDashboardService.add).toHaveBeenCalled();
+            expect(this.reportDashboardService.edit).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/admin-report-edit/admin-report-edit.html
+++ b/src/admin-report-edit/admin-report-edit.html
@@ -18,16 +18,6 @@
             </ul>
           </fieldset>
           <fieldset class="form-group">
-            <label for="URL" class="is-required">{{:: 'adminReportEdit.URL' | message}}</label>
-            <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('url')}">
-              <input type="text" id="URL" style="width: 100%" ng-model="vm.report.url"
-                ng-change="vm.validateField(vm.report.url, 'url')" required />
-            </div>
-            <ul class="openlmis-invalid" ng-if="vm.invalidFields.has('url')">
-              <li>{{'adminReportEdit.fieldRequired' | message}}</li>
-            </ul>
-          </fieldset>
-          <fieldset class="form-group">
             <label for="category" class="is-required">{{:: 'adminReportEdit.category' | message}}</label>
             <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('category')}">
               <select id="category" ng-change="vm.validateField(vm.report.category, 'category')"
@@ -41,7 +31,7 @@
           <fieldset class="form-group">
             <label for="type" class="is-required">{{:: 'adminReportEdit.type' | message}}</label>
             <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('type')}">
-              <select id="type" ng-change="vm.validateField(vm.report.type, 'type')"
+              <select id="type" ng-change="vm.onTypeChange()"
                 ng-model="vm.report.type" ng-options="type for type in vm.types"
                 required></select>
             </div>
@@ -49,6 +39,26 @@
               <li>{{'adminReportEdit.fieldRequired' | message}}</li>
             </ul>
           </fieldset>
+          <fieldset class="form-group" ng-if="vm.report.type === 'SUPERSET'">
+            <label for="embeddedUuid">{{:: 'adminReportEdit.embeddedUuid' | message}}</label>
+            <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('supersetField')}">
+              <input type="text" id="embeddedUuid" style="width: 100%" ng-model="vm.report.embeddedUuid"
+                ng-change="vm.validateSupersetFields()" />
+            </div>
+          </fieldset>
+          <fieldset class="form-group">
+            <label for="URL" ng-class="{'is-required': vm.report.type !== 'SUPERSET'}">{{:: 'adminReportEdit.URL' | message}}</label>
+            <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('url')}">
+              <input type="text" id="URL" style="width: 100%" ng-model="vm.report.url"
+                ng-change="vm.validateField(vm.report.url, 'url'); vm.validateSupersetFields()" />
+            </div>
+            <ul class="openlmis-invalid" ng-if="vm.invalidFields.has('url')">
+              <li>{{'adminReportEdit.fieldRequired' | message}}</li>
+            </ul>
+          </fieldset>
+          <ul class="openlmis-invalid" ng-if="vm.invalidFields.has('supersetField')">
+            <li>{{'adminReportEdit.supersetFieldRequired' | message}}</li>
+          </ul>
           <fieldset class="form-group">
             <label for="enabled">
               <input id="enabled" type="checkbox" ng-model="vm.report.enabled" />

--- a/src/admin-report-edit/admin-report-edit.html
+++ b/src/admin-report-edit/admin-report-edit.html
@@ -39,7 +39,7 @@
               <li>{{'adminReportEdit.fieldRequired' | message}}</li>
             </ul>
           </fieldset>
-          <fieldset class="form-group" ng-if="vm.report.type === 'SUPERSET'">
+          <fieldset class="form-group" ng-if="vm.report.type === vm.REPORT_TYPES.SUPERSET">
             <label for="embeddedUuid">{{:: 'adminReportEdit.embeddedUuid' | message}}</label>
             <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('supersetField')}">
               <input type="text" id="embeddedUuid" style="width: 100%" ng-model="vm.report.embeddedUuid"
@@ -47,7 +47,7 @@
             </div>
           </fieldset>
           <fieldset class="form-group">
-            <label for="URL" ng-class="{'is-required': vm.report.type !== 'SUPERSET'}">{{:: 'adminReportEdit.URL' | message}}</label>
+            <label for="URL" ng-class="{'is-required': vm.report.type !== vm.REPORT_TYPES.SUPERSET}">{{:: 'adminReportEdit.URL' | message}}</label>
             <div class="input-control" ng-class="{'is-invalid': vm.invalidFields.has('url')}">
               <input type="text" id="URL" style="width: 100%" ng-model="vm.report.url"
                 ng-change="vm.validateField(vm.report.url, 'url'); vm.validateSupersetFields()" />

--- a/src/admin-report-edit/admin-report-edit.module.js
+++ b/src/admin-report-edit/admin-report-edit.module.js
@@ -25,10 +25,13 @@
     angular.module('admin-report-edit', [
         'ngResource',
         'openlmis-i18n',
-        'openlmis-rights',
-        'openlmis-urls',
-        'openlmis-permissions',
+        'openlmis-modal',
+        'openlmis-modal-state',
         'openlmis-pagination',
+        'openlmis-permissions',
+        'openlmis-rights',
+        'openlmis-state-tracker',
+        'openlmis-urls',
         'ui.router',
         'report-dashboard'
     ]);

--- a/src/admin-report-edit/messages_en.json
+++ b/src/admin-report-edit/messages_en.json
@@ -13,5 +13,7 @@
     "adminReportEdit.error": "Failed to edit dashboard report",
     "adminReportEdit.showOnHomePage": "Show on home page",
     "adminReportEdit.type": "Type",
+    "adminReportEdit.embeddedUuid": "Embedded UUID",
+    "adminReportEdit.supersetFieldRequired": "Provide either a URL or an Embedded UUID.",
     "adminReportEdit.confirmChangeOfHomePageReport": "Are you sure you want ${newReport} report to replace the ${actualReport} report on the home page?"
 }


### PR DESCRIPTION
Added support for setting UUID for reports embedded for new version of Superset (6.0). It's backwards compatible with old reporting versions, users will need to fill either URL  for old reporting system or UUID for the new one. Validation makes sure that at least one of them is set if superset is used as a report category.