### PR TITLE
OLMIS-8220: Raise header z-index above sticky content

### DIFF
--- a/src/openlmis-header/_header.scss
+++ b/src/openlmis-header/_header.scss
@@ -3,6 +3,8 @@ $font-size-openlmis-header-title: $font-size-extra-large !default;
 body > header {
   border: 0px;
   padding: 0px;
+  position: relative;
+  z-index: $z-index-header-sticky;
   > * {
     width: 100%;
     margin: 0px;


### PR DESCRIPTION
Header now uses the shared layer variable so language dropdown stays on top.