### PR TITLE
OLMIS-8121: Fix typo in report category success toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Improvements:
   * Other minor layout/font improvements
 New functionality:
 * [MW-1449](https://openlmis.atlassian.net/browse/MW-1449): Added Embedded UUID field to the dashboard report admin form. For Superset reports, either URL or Embedded UUID is required; for other report types, URL remains required.
+Bug fixes:
+* [OLMIS-8121](https://openlmis.atlassian.net/browse/OLMIS-8121): Fix typo in the report category success notification.
 
 5.6.18 / 2026-02-05
 ==================

--- a/src/admin-report-category-add/messages_en.json
+++ b/src/admin-report-category-add/messages_en.json
@@ -6,6 +6,6 @@
     "adminReportCategoryAdd.save": "Save",
     "adminReportCategoryAdd.cancel": "Cancel",
     "adminReportCategoryAdd.fieldRequired": "This field is required",
-    "adminReportCategoryAdd.success": "Rreport category created successfully",
+    "adminReportCategoryAdd.success": "Report category created successfully",
     "adminReportCategoryAdd.error": "Failed to create report category"
 }


### PR DESCRIPTION
Corrects "Rreport" to "Report" in the add report category success notification.