### PR TITLE
OLMIS-6624: Fix role tab active state

### DIFF
--- a/src/admin-user-roles/user-role-tabs.html
+++ b/src/admin-user-roles/user-role-tabs.html
@@ -1,6 +1,6 @@
 <nav>
     <ul>
-        <li ng-repeat="type in vm.roleTypes" ui-sref-active="active" role="presentation">
+        <li ng-repeat="type in vm.roleTypes" ng-class="{ active: vm.isRoleTypeActive(type) }" role="presentation">
             <a ui-sref=".{{type}}({page: 0})">
                 {{vm.getRoleTypeLabel(type) | message}}
             </a>

--- a/src/admin-user-roles/user-roles.controller.js
+++ b/src/admin-user-roles/user-roles.controller.js
@@ -38,6 +38,7 @@
         vm.goToUserList = goToUserList;
         vm.saveUserRoles = saveUserRoles;
         vm.getRoleTypeLabel = getRoleTypeLabel;
+        vm.isRoleTypeActive = isRoleTypeActive;
 
         /**
          * @ngdoc property
@@ -125,6 +126,22 @@
          */
         function getRoleTypeLabel(type) {
             return ROLE_TYPES.getLabel(type);
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf admin-user-roles.controller:UserRolesController
+         * @name isRoleTypeActive
+         *
+         * @description
+         * Indicates whether the tab for the given role type is active, regardless of the currently
+         * selected page of the role assignments list.
+         *
+         * @param  {String}  type the role type name
+         * @return {Boolean}      true if the role type tab is active, false otherwise
+         */
+        function isRoleTypeActive(type) {
+            return $state.includes('openlmis.administration.users.roles.' + type);
         }
     }
 })();

--- a/src/admin-user-roles/user-roles.controller.spec.js
+++ b/src/admin-user-roles/user-roles.controller.spec.js
@@ -138,4 +138,21 @@ describe('UserRolesController', function() {
                 .toEqual(this.ROLE_TYPES.getLabel(this.ROLE_TYPES.SUPERVISION));
         });
     });
+
+    describe('isRoleTypeActive', function() {
+
+        it('should be active when the role type state is included regardless of page', function() {
+            spyOn(this.$state, 'includes').andReturn(true);
+
+            expect(this.vm.isRoleTypeActive(this.ROLE_TYPES.SUPERVISION)).toBe(true);
+            expect(this.$state.includes)
+                .toHaveBeenCalledWith('openlmis.administration.users.roles.' + this.ROLE_TYPES.SUPERVISION);
+        });
+
+        it('should not be active when the role type state is not included', function() {
+            spyOn(this.$state, 'includes').andReturn(false);
+
+            expect(this.vm.isRoleTypeActive(this.ROLE_TYPES.SUPERVISION)).toBe(false);
+        });
+    });
 });

--- a/src/openlmis-user/user-profile-role-assignments.controller.js
+++ b/src/openlmis-user/user-profile-role-assignments.controller.js
@@ -28,14 +28,15 @@
         .module('openlmis-user')
         .controller('UserProfileRoleAssignmentsController', controller);
 
-    controller.$inject = ['user', 'ROLE_TYPES'];
+    controller.$inject = ['user', 'ROLE_TYPES', '$state'];
 
-    function controller(user, ROLE_TYPES) {
+    function controller(user, ROLE_TYPES, $state) {
 
         var vm = this;
 
         vm.$onInit = onInit;
         vm.getRoleTypeLabel = ROLE_TYPES.getLabel;
+        vm.isRoleTypeActive = isRoleTypeActive;
 
         /**
          * @ngdoc property
@@ -70,6 +71,22 @@
         function onInit() {
             vm.user = user;
             vm.roleTypes = ROLE_TYPES.getRoleTypes();
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf openlmis-user.controller:UserProfileRoleAssignmentsController
+         * @name isRoleTypeActive
+         *
+         * @description
+         * Indicates whether the tab for the given role type is active, regardless of the currently
+         * selected page of the role assignments list.
+         *
+         * @param  {String}  type the role type name
+         * @return {Boolean}      true if the role type tab is active, false otherwise
+         */
+        function isRoleTypeActive(type) {
+            return $state.includes('openlmis.profile.roleAssignments.' + type);
         }
 
     }

--- a/src/openlmis-user/user-profile-role-assignments.controller.spec.js
+++ b/src/openlmis-user/user-profile-role-assignments.controller.spec.js
@@ -21,6 +21,7 @@ describe('UserProfileRoleAssignmentsController', function() {
         inject(function($injector) {
             this.$controller = $injector.get('$controller');
             this.$q = $injector.get('$q');
+            this.$state = $injector.get('$state');
             this.ROLE_TYPES = $injector.get('ROLE_TYPES');
             this.UserDataBuilder = $injector.get('UserDataBuilder');
         });
@@ -44,6 +45,24 @@ describe('UserProfileRoleAssignmentsController', function() {
 
         it('should expose role types', function() {
             expect(this.vm.roleTypes).toEqual(this.ROLE_TYPES.getRoleTypes());
+        });
+
+    });
+
+    describe('isRoleTypeActive', function() {
+
+        it('should be active when the role type state is included regardless of page', function() {
+            spyOn(this.$state, 'includes').andReturn(true);
+
+            expect(this.vm.isRoleTypeActive(this.ROLE_TYPES.SUPERVISION)).toBe(true);
+            expect(this.$state.includes)
+                .toHaveBeenCalledWith('openlmis.profile.roleAssignments.' + this.ROLE_TYPES.SUPERVISION);
+        });
+
+        it('should not be active when the role type state is not included', function() {
+            spyOn(this.$state, 'includes').andReturn(false);
+
+            expect(this.vm.isRoleTypeActive(this.ROLE_TYPES.SUPERVISION)).toBe(false);
         });
 
     });


### PR DESCRIPTION
The chosen role type tab stays active when navigating to a later page of role assignments.