### PR TITLE
OLMIS-8238: Add facility packs/doses configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Upcoming Version (WIP)
 ==================
 Improvements:
+* [OLMIS-8238](https://openlmis.atlassian.net/browse/OLMIS-8238): Configure facility packs/doses display mode.
 * [OLMIS-8219](https://openlmis.atlassian.net/browse/OLMIS-8219): Vertically align logout button and language picker in navbar
 * [OLMIS-8217](https://openlmis.atlassian.net/browse/OLMIS-8217): Improve home facility alerts panel UI and functionality. 
   * Display actual facility name instead of `My Facility data`

--- a/src/admin-facility-add/facility-add.controller.js
+++ b/src/admin-facility-add/facility-add.controller.js
@@ -32,13 +32,13 @@
     FacilityAddController.$inject = [
         'facility', 'facilityTypes', 'geographicZones', 'facilityOperators', 'confirmService',
         'FacilityRepository', 'stateTrackerService', '$state', 'loadingModalService',
-        'notificationService', 'messageService'
+        'notificationService', 'messageService', 'QUANTITY_UNIT_DISPLAY_OPTIONS'
     ];
 
     function FacilityAddController(facility, facilityTypes, geographicZones, facilityOperators,
                                    confirmService, FacilityRepository, stateTrackerService,
                                    $state, loadingModalService, notificationService,
-                                   messageService) {
+                                   messageService, QUANTITY_UNIT_DISPLAY_OPTIONS) {
         var vm = this;
 
         vm.$onInit = onInit;
@@ -60,6 +60,13 @@
             vm.facilityOperators = facilityOperators;
             vm.facility.active = facility.active !== false;
             vm.facility.enabled = facility.enabled !== false;
+            vm.facility.extraData = vm.facility.extraData || {};
+            vm.quantityUnitDisplayOptions = QUANTITY_UNIT_DISPLAY_OPTIONS.map(function(option) {
+                return {
+                    value: option.value,
+                    name: messageService.get(option.messageKey)
+                };
+            });
         }
 
         /**

--- a/src/admin-facility-add/facility-add.controller.spec.js
+++ b/src/admin-facility-add/facility-add.controller.spec.js
@@ -123,6 +123,43 @@ describe('FacilityAddController', function() {
             expect(this.vm.facility).not.toBe(this.facility);
         });
 
+        it('should initialize extraData when missing', function() {
+            this.facility.extraData = undefined;
+
+            this.vm.$onInit();
+
+            expect(this.vm.facility.extraData).toEqual({});
+        });
+
+        it('should preserve existing extraData', function() {
+            this.facility.extraData = {
+                quantityUnitDisplay: 'PACKS'
+            };
+
+            this.vm.$onInit();
+
+            expect(this.vm.facility.extraData.quantityUnitDisplay).toEqual('PACKS');
+        });
+
+        it('should expose quantity unit display options', function() {
+            this.vm.$onInit();
+
+            var values = this.vm.quantityUnitDisplayOptions.map(function(option) {
+                return option.value;
+            });
+
+            expect(values).toEqual([undefined, 'PACKS', 'DOSES', 'BOTH']);
+        });
+
+        it('should label the quantity unit display options from the expected message keys', function() {
+            this.vm.$onInit();
+
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.systemDefault');
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.packsOnly');
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.dosesOnly');
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.packsAndDoses');
+        });
+
     });
 
     describe('save', function() {
@@ -184,6 +221,20 @@ describe('FacilityAddController', function() {
                     facility: this.facility
                 }
             );
+        });
+
+        it('should persist the selected quantity unit display in facility extraData', function() {
+            this.vm.facility.extraData = {
+                quantityUnitDisplay: 'PACKS'
+            };
+
+            this.vm.save();
+            this.confirmDeferred.reject();
+            this.saveDeferred.resolve();
+            this.$rootScope.$apply();
+
+            expect(this.FacilityRepository.prototype.create.calls[0].args[0].extraData.quantityUnitDisplay)
+                .toEqual('PACKS');
         });
 
     });

--- a/src/admin-facility-add/facility-information.html
+++ b/src/admin-facility-add/facility-information.html
@@ -24,3 +24,6 @@
     <textarea id="description" ng-model="vm.facility.description" ng-disabled="vm.managedExternally"></textarea>
     <label for="facilityOperator">{{'adminFacilityAdd.facilityOperator' | message}}</label>
     <select id="facilityOperator" ng-model="vm.facility.operator" ng-options="facilityOperator as facilityOperator.name for facilityOperator in vm.facilityOperators track by facilityOperator.id"></select>
+    <label for="quantityUnitDisplay">{{'adminFacilityAdd.quantityUnitDisplay' | message}}</label>
+    <select id="quantityUnitDisplay" ng-model="vm.facility.extraData.quantityUnitDisplay" ng-options="option.value as option.name for option in vm.quantityUnitDisplayOptions"></select>
+    <p class="note">{{'adminFacilityAdd.quantityUnitDisplay.description' | message}}</p>

--- a/src/admin-facility-add/messages_en.json
+++ b/src/admin-facility-add/messages_en.json
@@ -18,5 +18,11 @@
     "adminFacilityAdd.operationalDate.description": "This is used in reporting to record the date the facility becomes operational",
     "adminFacilityAdd.activeFacility.description": "This determines whether or not the facility can submit requisitions or receive deliveries",
     "adminFacilityAdd.enabled.description.checked": "Checked = The facility can operate",
-    "adminFacilityAdd.enabled.description.unchecked": "Unchecked = The facility is permanently decommissioned"
+    "adminFacilityAdd.enabled.description.unchecked": "Unchecked = The facility is permanently decommissioned",
+    "adminFacilityAdd.quantityUnitDisplay": "Quantity Display Unit",
+    "adminFacilityAdd.quantityUnitDisplay.description": "Determines whether quantities are shown in packs, in doses, or with a toggle between both for this facility's users",
+    "adminFacilityAdd.quantityUnitDisplay.systemDefault": "System default",
+    "adminFacilityAdd.quantityUnitDisplay.packsOnly": "Packs only",
+    "adminFacilityAdd.quantityUnitDisplay.dosesOnly": "Doses only",
+    "adminFacilityAdd.quantityUnitDisplay.packsAndDoses": "Packs and doses"
 }

--- a/src/admin-facility-view/facility-view.controller.js
+++ b/src/admin-facility-view/facility-view.controller.js
@@ -30,11 +30,13 @@
 
     controller.$inject = [
         '$q', '$state', 'facility', 'facilityTypes', 'geographicZones', 'facilityOperators',
-        'programs', 'FacilityRepository', 'loadingModalService', 'notificationService'
+        'programs', 'FacilityRepository', 'loadingModalService', 'notificationService',
+        'messageService', 'QUANTITY_UNIT_DISPLAY_OPTIONS'
     ];
 
     function controller($q, $state, facility, facilityTypes, geographicZones, facilityOperators,
-                        programs, FacilityRepository, loadingModalService, notificationService) {
+                        programs, FacilityRepository, loadingModalService, notificationService,
+                        messageService, QUANTITY_UNIT_DISPLAY_OPTIONS) {
 
         var vm = this;
 
@@ -128,6 +130,13 @@
             vm.programs = programs;
             vm.selectedTab = 0;
             vm.managedExternally = facility.isManagedExternally();
+            vm.facility.extraData = vm.facility.extraData || {};
+            vm.quantityUnitDisplayOptions = QUANTITY_UNIT_DISPLAY_OPTIONS.map(function(option) {
+                return {
+                    value: option.value,
+                    name: messageService.get(option.messageKey)
+                };
+            });
 
             if (!vm.facilityWithPrograms.supportedPrograms) {
                 vm.facilityWithPrograms.supportedPrograms = [];

--- a/src/admin-facility-view/facility-view.controller.spec.js
+++ b/src/admin-facility-view/facility-view.controller.spec.js
@@ -32,7 +32,10 @@ describe('FacilityViewController', function() {
             this.FacilityOperatorDataBuilder = $injector.get('FacilityOperatorDataBuilder');
             this.ProgramDataBuilder = $injector.get('ProgramDataBuilder');
             this.FacilityDataBuilder = $injector.get('FacilityDataBuilder');
+            this.messageService = $injector.get('messageService');
         });
+
+        spyOn(this.messageService, 'get').andCallThrough();
 
         spyOn(this.FacilityRepository.prototype, 'update').andReturn(this.$q.when());
 
@@ -107,6 +110,43 @@ describe('FacilityViewController', function() {
             expect(this.vm.programs).toEqual(this.programs);
         });
 
+        it('should initialize extraData when missing', function() {
+            this.facility.extraData = undefined;
+
+            this.vm.$onInit();
+
+            expect(this.vm.facility.extraData).toEqual({});
+        });
+
+        it('should preserve existing extraData', function() {
+            this.facility.extraData = {
+                quantityUnitDisplay: 'DOSES'
+            };
+
+            this.vm.$onInit();
+
+            expect(this.vm.facility.extraData.quantityUnitDisplay).toEqual('DOSES');
+        });
+
+        it('should expose quantity unit display options', function() {
+            this.vm.$onInit();
+
+            var values = this.vm.quantityUnitDisplayOptions.map(function(option) {
+                return option.value;
+            });
+
+            expect(values).toEqual([undefined, 'PACKS', 'DOSES', 'BOTH']);
+        });
+
+        it('should label the quantity unit display options from the expected message keys', function() {
+            this.vm.$onInit();
+
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.systemDefault');
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.packsOnly');
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.dosesOnly');
+            expect(this.messageService.get).toHaveBeenCalledWith('adminFacilityAdd.quantityUnitDisplay.packsAndDoses');
+        });
+
         it('should expose supported programs list', function() {
             expect(this.vm.facilityWithPrograms.supportedPrograms).toEqual([]);
         });
@@ -162,6 +202,18 @@ describe('FacilityViewController', function() {
             this.$rootScope.$apply();
 
             expect(this.FacilityRepository.prototype.update).toHaveBeenCalledWith(this.vm.facility);
+        });
+
+        it('should persist the selected quantity unit display in facility extraData', function() {
+            this.vm.facility.extraData = {
+                quantityUnitDisplay: 'DOSES'
+            };
+
+            this.vm.saveFacilityDetails();
+            this.$rootScope.$apply();
+
+            expect(this.FacilityRepository.prototype.update.calls[0].args[0].extraData.quantityUnitDisplay)
+                .toEqual('DOSES');
         });
 
         it('should close loading modal and show error notification after save fails', function() {

--- a/src/referencedata-facility/quantity-unit-display-options.constant.js
+++ b/src/referencedata-facility/quantity-unit-display-options.constant.js
@@ -1,0 +1,49 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc object
+     * @name referencedata-facility.QUANTITY_UNIT_DISPLAY_OPTIONS
+     *
+     * @description
+     * Single source of the facility-level "Quantity Display Unit" dropdown options, shared by the
+     * facility add and view screens so the contract stays in sync. The values mirror the
+     * openlmis-quantity-unit-toggle QUANTITY_UNIT constant (PACKS/DOSES/BOTH) and are stored in
+     * Facility.extraData.quantityUnitDisplay; they are kept as literals here so this module does not
+     * have to depend on the toggle module. An undefined value means "use the system default".
+     */
+    angular
+        .module('referencedata-facility')
+        .constant('QUANTITY_UNIT_DISPLAY_OPTIONS', [
+            {
+                value: undefined,
+                messageKey: 'adminFacilityAdd.quantityUnitDisplay.systemDefault'
+            }, {
+                value: 'PACKS',
+                messageKey: 'adminFacilityAdd.quantityUnitDisplay.packsOnly'
+            }, {
+                value: 'DOSES',
+                messageKey: 'adminFacilityAdd.quantityUnitDisplay.dosesOnly'
+            }, {
+                value: 'BOTH',
+                messageKey: 'adminFacilityAdd.quantityUnitDisplay.packsAndDoses'
+            }
+        ]);
+
+})();

--- a/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.js
+++ b/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.js
@@ -1,0 +1,151 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc function
+     * @name referencedata-quantity-unit.run:setQuantityUnitFromHomeFacility
+     *
+     * @description
+     * Applies the current user's home facility quantity unit display configuration
+     * (extraData.quantityUnitDisplay) to the shared quantityUnitConfigService. The mode is reset
+     * first so a user without facility-level configuration does not inherit the previous user's
+     * mode. It runs after login, and also on app bootstrap when a session already exists (e.g. a
+     * full page reload), because post-login actions only fire on an actual login. On logout the
+     * mode is reset so the next user starts from the build-time default.
+     *
+     * When online the home facility is fetched fresh (via FacilityResource, bypassing the shared
+     * facilityService cache which is intentionally aggressive for performance) so an admin's
+     * facility-level configuration change is picked up on the user's next login. When offline it
+     * falls back to the cached home facility (last-known configuration). Only this module reads the
+     * facility fresh - the shared facility cache and its performance characteristics are untouched.
+     *
+     * Note: on a hard reload the apply is asynchronous (fire-and-forget) while consumers read the
+     * mode synchronously once, so a deep-linked page may briefly render in the default mode until
+     * the home facility resolves; in practice this is short.
+     */
+    angular
+        .module('referencedata-quantity-unit')
+        .run(run);
+
+    run.$inject = [
+        '$q', '$rootScope', 'loginService', 'facilityFactory', 'quantityUnitConfigService',
+        'authorizationService', 'offlineService', 'currentUserService', 'FacilityResource',
+        'userPreferenceService', 'QUANTITY_UNIT'
+    ];
+
+    function run($q, $rootScope, loginService, facilityFactory, quantityUnitConfigService,
+                 authorizationService, offlineService, currentUserService, FacilityResource,
+                 userPreferenceService, QUANTITY_UNIT) {
+
+        loginService.registerPostLoginAction(applyQuantityUnitConfig);
+        loginService.registerPostLogoutAction(resetQuantityUnitMode);
+        $rootScope.$on('openlmis.quantityUnit.selected', persistSelectedUnit);
+
+        if (authorizationService.isAuthenticated()) {
+            applyQuantityUnitConfig();
+        }
+
+        function applyQuantityUnitConfig() {
+            quantityUnitConfigService.resetMode();
+
+            return getUser()
+                .then(function(user) {
+                    return getHomeFacility(user)
+                        .then(function(homeFacility) {
+                            var mode = homeFacility && homeFacility.extraData
+                                ? homeFacility.extraData.quantityUnitDisplay
+                                : undefined;
+
+                            if (mode) {
+                                quantityUnitConfigService.setMode(mode);
+                            }
+
+                            return restoreSelectedUnit(user);
+                        });
+                })
+                .catch(function() {
+                    // No home facility / user, or it could not be fetched - keep the default mode
+                    // and do not block login (matches the other post-login actions' convention).
+                    return undefined;
+                });
+        }
+
+        function getUser() {
+            if (offlineService.isOffline()) {
+                return $q.resolve(undefined);
+            }
+            return currentUserService.getUserInfo();
+        }
+
+        function getHomeFacility(user) {
+            if (offlineService.isOffline()) {
+                return facilityFactory.getUserHomeFacility();
+            }
+
+            if (!user || !user.homeFacilityId) {
+                return $q.reject();
+            }
+
+            return new FacilityResource().get(user.homeFacilityId);
+        }
+
+        // In BOTH mode the unit the user last selected is their per-user default, so it has to
+        // survive logout (which clears local storage). It is persisted server-side per user and
+        // restored here on the next login. Forced modes ignore the selection, so skip the fetch.
+        // Offline we cannot reach the server, so the last-known local value (if any) is kept.
+        function restoreSelectedUnit(user) {
+            if (offlineService.isOffline()
+                || quantityUnitConfigService.getMode() !== QUANTITY_UNIT.BOTH
+                || !user || !user.id) {
+                return undefined;
+            }
+
+            return userPreferenceService.get(user.id)
+                .then(function(preferences) {
+                    if (preferences && preferences.quantityUnit) {
+                        quantityUnitConfigService.setSelectedUnit(preferences.quantityUnit);
+                    }
+                })
+                .catch(function() {
+                    return undefined;
+                });
+        }
+
+        function persistSelectedUnit(event, unit) {
+            return currentUserService.getUserInfo()
+                .then(function(user) {
+                    if (user && user.id) {
+                        return userPreferenceService.save(user.id, {
+                            quantityUnit: unit
+                        });
+                    }
+                    return undefined;
+                })
+                .catch(function() {
+                    return undefined;
+                });
+        }
+
+        function resetQuantityUnitMode() {
+            quantityUnitConfigService.resetMode();
+            return undefined;
+        }
+    }
+
+})();

--- a/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.spec.js
+++ b/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.spec.js
@@ -13,6 +13,10 @@
  * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
  */
 
+function getLastCallArg(method) {
+    return method.calls[method.calls.length - 1].args[0];
+}
+
 describe('referencedata-quantity-unit run', function() {
 
     var loginServiceSpy, facilityFactory, quantityUnitConfigService, authorizationService,
@@ -67,10 +71,6 @@ describe('referencedata-quantity-unit run', function() {
                 }
             ));
         });
-    }
-
-    function getLastCallArg(method) {
-        return method.calls[method.calls.length - 1].args[0];
     }
 
     function triggerLogin() {

--- a/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.spec.js
+++ b/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.spec.js
@@ -1,0 +1,274 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('referencedata-quantity-unit run', function() {
+
+    var loginServiceSpy, facilityFactory, quantityUnitConfigService, authorizationService,
+        offlineService, currentUserService, facilityResource, userPreferenceService,
+        $rootScope, $q, QUANTITY_UNIT;
+
+    function setUp(config) {
+        config = config || {};
+
+        loginServiceSpy = jasmine.createSpyObj('loginService', [
+            'registerPostLoginAction', 'registerPostLogoutAction'
+        ]);
+        quantityUnitConfigService = jasmine.createSpyObj('quantityUnitConfigService', [
+            'setMode', 'resetMode', 'getMode', 'setSelectedUnit'
+        ]);
+        quantityUnitConfigService.getMode.andReturn(config.mode || 'BOTH');
+        authorizationService = jasmine.createSpyObj('authorizationService', ['isAuthenticated']);
+        authorizationService.isAuthenticated.andReturn(!!config.authenticated);
+        facilityFactory = jasmine.createSpyObj('facilityFactory', ['getUserHomeFacility']);
+        offlineService = jasmine.createSpyObj('offlineService', ['isOffline']);
+        offlineService.isOffline.andReturn(!!config.offline);
+        currentUserService = jasmine.createSpyObj('currentUserService', ['getUserInfo']);
+        facilityResource = jasmine.createSpyObj('FacilityResource', ['get']);
+        userPreferenceService = jasmine.createSpyObj('userPreferenceService', ['get', 'save']);
+        QUANTITY_UNIT = {
+            PACKS: 'PACKS',
+            DOSES: 'DOSES',
+            BOTH: 'BOTH'
+        };
+
+        module('referencedata-quantity-unit', function($provide) {
+            $provide.value('loginService', loginServiceSpy);
+            $provide.value('facilityFactory', facilityFactory);
+            $provide.value('quantityUnitConfigService', quantityUnitConfigService);
+            $provide.value('authorizationService', authorizationService);
+            $provide.value('offlineService', offlineService);
+            $provide.value('currentUserService', currentUserService);
+            $provide.value('FacilityResource', function() {
+                return facilityResource;
+            });
+            $provide.value('userPreferenceService', userPreferenceService);
+            $provide.value('QUANTITY_UNIT', QUANTITY_UNIT);
+        });
+
+        inject(function($injector) {
+            $rootScope = $injector.get('$rootScope');
+            $q = $injector.get('$q');
+            currentUserService.getUserInfo.andReturn($q.when(
+                config.user || {
+                    id: 'user-1',
+                    homeFacilityId: 'home-1'
+                }
+            ));
+        });
+    }
+
+    function getLastCallArg(method) {
+        return method.calls[method.calls.length - 1].args[0];
+    }
+
+    function triggerLogin() {
+        getLastCallArg(loginServiceSpy.registerPostLoginAction)();
+        $rootScope.$apply();
+    }
+
+    describe('registration', function() {
+
+        beforeEach(function() {
+            setUp();
+        });
+
+        it('should register a post login action', function() {
+            expect(loginServiceSpy.registerPostLoginAction).toHaveBeenCalled();
+        });
+
+        it('should register a post logout action', function() {
+            expect(loginServiceSpy.registerPostLogoutAction).toHaveBeenCalled();
+        });
+
+        it('should not apply on bootstrap when the user is not authenticated', function() {
+            expect(quantityUnitConfigService.resetMode).not.toHaveBeenCalled();
+            expect(currentUserService.getUserInfo).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('post login action (online)', function() {
+
+        beforeEach(function() {
+            setUp();
+        });
+
+        it('should fetch the home facility FRESH and set the mode from its extra data', function() {
+            facilityResource.get.andReturn($q.when({
+                extraData: {
+                    quantityUnitDisplay: 'PACKS'
+                }
+            }));
+            quantityUnitConfigService.getMode.andReturn('PACKS');
+
+            triggerLogin();
+
+            expect(quantityUnitConfigService.resetMode).toHaveBeenCalled();
+            expect(facilityResource.get).toHaveBeenCalledWith('home-1');
+            expect(facilityFactory.getUserHomeFacility).not.toHaveBeenCalled();
+            expect(quantityUnitConfigService.setMode).toHaveBeenCalledWith('PACKS');
+        });
+
+        it('should restore the user selected unit from the server when mode is BOTH', function() {
+            facilityResource.get.andReturn($q.when({
+                extraData: {
+                    quantityUnitDisplay: 'BOTH'
+                }
+            }));
+            quantityUnitConfigService.getMode.andReturn('BOTH');
+            userPreferenceService.get.andReturn($q.when({
+                quantityUnit: 'PACKS'
+            }));
+
+            triggerLogin();
+
+            expect(userPreferenceService.get).toHaveBeenCalledWith('user-1');
+            expect(quantityUnitConfigService.setSelectedUnit).toHaveBeenCalledWith('PACKS');
+        });
+
+        it('should NOT restore the selected unit when the facility forces a single mode', function() {
+            facilityResource.get.andReturn($q.when({
+                extraData: {
+                    quantityUnitDisplay: 'DOSES'
+                }
+            }));
+            quantityUnitConfigService.getMode.andReturn('DOSES');
+
+            triggerLogin();
+
+            expect(userPreferenceService.get).not.toHaveBeenCalled();
+            expect(quantityUnitConfigService.setSelectedUnit).not.toHaveBeenCalled();
+        });
+
+        it('should not set the selected unit when the server has no stored preference', function() {
+            facilityResource.get.andReturn($q.when({
+                extraData: {
+                    quantityUnitDisplay: 'BOTH'
+                }
+            }));
+            quantityUnitConfigService.getMode.andReturn('BOTH');
+            userPreferenceService.get.andReturn($q.when({}));
+
+            triggerLogin();
+
+            expect(userPreferenceService.get).toHaveBeenCalled();
+            expect(quantityUnitConfigService.setSelectedUnit).not.toHaveBeenCalled();
+        });
+
+        it('should resolve (not block login) when the user has no home facility', function() {
+            currentUserService.getUserInfo.andReturn($q.when({ id: 'user-1' }));
+
+            var resolved = false;
+            getLastCallArg(loginServiceSpy.registerPostLoginAction)().then(function() {
+                resolved = true;
+            });
+            $rootScope.$apply();
+
+            expect(facilityResource.get).not.toHaveBeenCalled();
+            expect(quantityUnitConfigService.setMode).not.toHaveBeenCalled();
+            expect(resolved).toBe(true);
+        });
+
+        it('should resolve (not block login) when the fresh fetch fails', function() {
+            facilityResource.get.andReturn($q.reject('error'));
+
+            var resolved = false;
+            getLastCallArg(loginServiceSpy.registerPostLoginAction)().then(function() {
+                resolved = true;
+            });
+            $rootScope.$apply();
+
+            expect(quantityUnitConfigService.resetMode).toHaveBeenCalled();
+            expect(quantityUnitConfigService.setMode).not.toHaveBeenCalled();
+            expect(resolved).toBe(true);
+        });
+    });
+
+    describe('post login action (offline)', function() {
+
+        beforeEach(function() {
+            setUp({ offline: true });
+        });
+
+        it('should fall back to the cached home facility and NOT fetch fresh or hit the server',
+            function() {
+                facilityFactory.getUserHomeFacility.andReturn($q.when({
+                    extraData: {
+                        quantityUnitDisplay: 'BOTH'
+                    }
+                }));
+                quantityUnitConfigService.getMode.andReturn('BOTH');
+
+                triggerLogin();
+
+                expect(facilityFactory.getUserHomeFacility).toHaveBeenCalled();
+                expect(facilityResource.get).not.toHaveBeenCalled();
+                expect(quantityUnitConfigService.setMode).toHaveBeenCalledWith('BOTH');
+                expect(userPreferenceService.get).not.toHaveBeenCalled();
+            });
+    });
+
+    describe('persisting the selected unit', function() {
+
+        beforeEach(function() {
+            setUp();
+        });
+
+        it('should save the selected unit per user when the selection event fires', function() {
+            userPreferenceService.save.andReturn($q.when({}));
+
+            $rootScope.$emit('openlmis.quantityUnit.selected', 'PACKS');
+            $rootScope.$apply();
+
+            expect(userPreferenceService.save).toHaveBeenCalledWith('user-1', {
+                quantityUnit: 'PACKS'
+            });
+        });
+    });
+
+    describe('post logout action', function() {
+
+        beforeEach(function() {
+            setUp();
+        });
+
+        it('should reset the mode', function() {
+            getLastCallArg(loginServiceSpy.registerPostLogoutAction)();
+
+            expect(quantityUnitConfigService.resetMode).toHaveBeenCalled();
+        });
+    });
+
+    describe('on bootstrap when already authenticated', function() {
+
+        it('should apply the home facility mode on bootstrap without waiting for a login',
+            function() {
+                setUp({
+                    authenticated: true,
+                    offline: true
+                });
+                facilityFactory.getUserHomeFacility.andReturn($q.when({
+                    extraData: {
+                        quantityUnitDisplay: 'DOSES'
+                    }
+                }));
+
+                $rootScope.$apply();
+
+                expect(quantityUnitConfigService.resetMode).toHaveBeenCalled();
+                expect(quantityUnitConfigService.setMode).toHaveBeenCalledWith('DOSES');
+            });
+    });
+
+});

--- a/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.spec.js
+++ b/src/referencedata-quantity-unit/quantity-unit-from-home-facility.run.spec.js
@@ -167,7 +167,9 @@ describe('referencedata-quantity-unit run', function() {
         });
 
         it('should resolve (not block login) when the user has no home facility', function() {
-            currentUserService.getUserInfo.andReturn($q.when({ id: 'user-1' }));
+            currentUserService.getUserInfo.andReturn($q.when({
+                id: 'user-1'
+            }));
 
             var resolved = false;
             getLastCallArg(loginServiceSpy.registerPostLoginAction)().then(function() {
@@ -198,7 +200,9 @@ describe('referencedata-quantity-unit run', function() {
     describe('post login action (offline)', function() {
 
         beforeEach(function() {
-            setUp({ offline: true });
+            setUp({
+                offline: true
+            });
         });
 
         it('should fall back to the cached home facility and NOT fetch fresh or hit the server',

--- a/src/referencedata-quantity-unit/referencedata-quantity-unit.module.js
+++ b/src/referencedata-quantity-unit/referencedata-quantity-unit.module.js
@@ -1,0 +1,30 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @module referencedata-quantity-unit
+     *
+     * @description
+     * Bridges the current user's home facility configuration (referencedata) to the shared
+     * quantity unit display mode (openlmis-quantity-unit-toggle). Kept as a separate module so the
+     * referencedata-facility module does not need to depend on the toggle module.
+     */
+    angular.module('referencedata-quantity-unit', []);
+
+})();

--- a/src/referencedata-user/user-preference.service.js
+++ b/src/referencedata-user/user-preference.service.js
@@ -1,0 +1,79 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+(function() {
+
+    'use strict';
+
+    /**
+     * @ngdoc service
+     * @name referencedata-user.userPreferenceService
+     *
+     * @description
+     * Reads and writes the current user's preferences (a generic key-value map) through the
+     * reference data /api/users/{userId}/preferences endpoint. Used to persist UI display
+     * preferences per user so that they survive logout (which clears local storage).
+     */
+    angular
+        .module('referencedata-user')
+        .service('userPreferenceService', service);
+
+    service.$inject = ['$http', 'openlmisUrlFactory'];
+
+    function service($http, openlmisUrlFactory) {
+
+        this.get = get;
+        this.save = save;
+
+        /**
+         * @ngdoc method
+         * @methodOf referencedata-user.userPreferenceService
+         * @name get
+         *
+         * @description
+         * Retrieves all of the given user's preferences as a key-value map.
+         *
+         * @param  {String}  userId the UUID of the user
+         * @return {Promise}        resolving to a map of preference key to value
+         */
+        function get(userId) {
+            return $http
+                .get(openlmisUrlFactory('/api/users/' + userId + '/preferences'))
+                .then(function(response) {
+                    return response.data;
+                });
+        }
+
+        /**
+         * @ngdoc method
+         * @methodOf referencedata-user.userPreferenceService
+         * @name save
+         *
+         * @description
+         * Creates or updates the given user's preferences. Only the provided keys are affected.
+         *
+         * @param  {String}  userId      the UUID of the user
+         * @param  {Object}  preferences a map of preference key to value to store
+         * @return {Promise}             resolving to the user's full set of preferences
+         */
+        function save(userId, preferences) {
+            return $http
+                .put(openlmisUrlFactory('/api/users/' + userId + '/preferences'), preferences)
+                .then(function(response) {
+                    return response.data;
+                });
+        }
+    }
+})();

--- a/src/referencedata-user/user-preference.service.spec.js
+++ b/src/referencedata-user/user-preference.service.spec.js
@@ -1,0 +1,76 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2017 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Affero General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+ * See the GNU Affero General Public License for more details. You should have received a copy of
+ * the GNU Affero General Public License along with this program. If not, see
+ * http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+describe('userPreferenceService', function() {
+
+    var userPreferenceService, $httpBackend, openlmisUrlFactory, userId;
+
+    beforeEach(function() {
+        module('referencedata-user');
+
+        inject(function($injector) {
+            userPreferenceService = $injector.get('userPreferenceService');
+            $httpBackend = $injector.get('$httpBackend');
+            openlmisUrlFactory = $injector.get('openlmisUrlFactory');
+        });
+
+        userId = 'user-1';
+    });
+
+    afterEach(function() {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    describe('get', function() {
+
+        it('should GET the user preferences map and resolve to it', function() {
+            $httpBackend
+                .expectGET(openlmisUrlFactory('/api/users/' + userId + '/preferences'))
+                .respond(200, {
+                    quantityUnit: 'PACKS'
+                });
+
+            var result;
+            userPreferenceService.get(userId).then(function(data) {
+                result = data;
+            });
+            $httpBackend.flush();
+
+            expect(result.quantityUnit).toEqual('PACKS');
+        });
+    });
+
+    describe('save', function() {
+
+        it('should PUT the preferences and resolve to the response', function() {
+            var preferences = {
+                quantityUnit: 'DOSES'
+            };
+
+            $httpBackend
+                .expectPUT(openlmisUrlFactory('/api/users/' + userId + '/preferences'), preferences)
+                .respond(200, preferences);
+
+            var result;
+            userPreferenceService.save(userId, preferences).then(function(data) {
+                result = data;
+            });
+            $httpBackend.flush();
+
+            expect(result.quantityUnit).toEqual('DOSES');
+        });
+    });
+});


### PR DESCRIPTION
Part of OLMIS-8238. Admin sets a facility display mode; on login it is applied from the home facility and the user's unit choice is restored from / saved to the preferences endpoint.

https://openlmis.atlassian.net/browse/OLMIS-8238