### PR TITLE
OLMIS-8191: Wrap long read-only text in admin lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 5.6.20-SNAPSHOT (WIP)
 ==================
+* [OLMIS-8191](https://openlmis.atlassian.net/browse/OLMIS-8191): Wrap long read-only text in admin lists — the System Notifications message (previously cropped), and Role/Product/Processing period descriptions.
 
 5.6.19 / 2026-06-09
 ==================

--- a/src/admin-orderable-list/orderable-list.html
+++ b/src/admin-orderable-list/orderable-list.html
@@ -35,7 +35,7 @@
             <tr ng-repeat="orderable in vm.orderables">
                 <td>{{orderable.productCode}}</td>
                 <td>{{orderable.fullProductName}}</td>
-                <td>{{orderable.description}}</td>
+                <td><span class="openlmis-long-text">{{orderable.description}}</span></td>
                 <td>
                     <button ui-sref=".edit.general({id: orderable.id})">{{'adminOrderableList.edit' | message}}</button>
                 </td>

--- a/src/admin-processing-schedule-edit/processing-schedule-edit.html
+++ b/src/admin-processing-schedule-edit/processing-schedule-edit.html
@@ -50,7 +50,7 @@
                         <tbody>
                             <tr ng-repeat="period in vm.processingPeriods">
                                 <td>{{period.name}}</td>
-                                <td>{{period.description}}</td>
+                                <td><span class="openlmis-long-text">{{period.description}}</span></td>
                                 <td>{{period.startDate | openlmisDate}}</td>
                                 <td>{{period.endDate | openlmisDate}}</td>
                                 <td>

--- a/src/admin-role-list/role-list.html
+++ b/src/admin-role-list/role-list.html
@@ -15,7 +15,7 @@
         <tr ng-repeat="role in vm.rolesPage">
             <td>{{role.name}}</td>
             <td>{{role.rights[0].type | roleType}}</td>
-            <td>{{role.description}}</td>
+            <td><span class="openlmis-long-text">{{role.description}}</span></td>
             <td>{{role.count}}</td>
             <td>
                 <a ui-sref=".createUpdate({roleId: role.id})">{{'adminRoleList.edit' | message}}</a>

--- a/src/admin-system-notification-list/_crop-long-text.scss
+++ b/src/admin-system-notification-list/_crop-long-text.scss
@@ -1,6 +1,0 @@
-.crop-long-text {
-  max-width: 30em;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}

--- a/src/admin-system-notification-list/system-notification-list.html
+++ b/src/admin-system-notification-list/system-notification-list.html
@@ -36,7 +36,7 @@
                 <td>{{systemNotification.createdDate | openlmisDate}}</td>
                 <td><openlmis-ok-icon show="systemNotification.active"></openlmis-ok-icon></td>
                 <td><openlmis-ok-icon show="systemNotification.isDisplayed"></openlmis-ok-icon></td>
-                <td class="crop-long-text">{{systemNotification.message}}</td>
+                <td><span class="openlmis-long-text">{{systemNotification.message}}</span></td>
                 <td>
                     <button class="primary"
                         ui-sref=".edit({id: systemNotification.id})">{{'adminSystemNotificationList.edit' | message}}</button>


### PR DESCRIPTION
## What
Wrap long read-only text via the shared `openlmis-long-text` class:
- System Notifications message (was cropped with an ellipsis — now shows the full text, wrapped).
- Role / Product / Processing period descriptions.
Removes the now-unused `_crop-long-text.scss`.

## Note
The description columns already wrapped at wide widths; the class adds a width cap and keeps them readable (holding width) at narrow widths, consistent with the other screens.

## Depends on
openlmis-ui-components PR (same branch).

OLMIS-8191
