### PR TITLE
OLMIS-7247: Fix system notifications not refreshing without a page reload or re-login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 5.6.20-SNAPSHOT (WIP)
 ==================
+Bug fixes:
+* [OLMIS-7247](https://openlmis.atlassian.net/browse/OLMIS-7247): Fixed system notifications not refreshing without re-login.
+  * Clear the cached notifications after creating/editing a notification so the home page banner and indicator update immediately.
+  * Filter the cached list by the current active window on every read so expired or deactivated notifications stop being displayed without logging out.
 
 5.6.19 / 2026-06-09
 ==================

--- a/src/admin-system-notification-edit/admin-system-notification-edit.controller.js
+++ b/src/admin-system-notification-edit/admin-system-notification-edit.controller.js
@@ -30,13 +30,14 @@
 
     adminSystemNotificationEditController.$inject = [
         'systemNotification', 'author', 'FunctionDecorator', 'SystemNotificationResource', 'successNotificationKey',
-        'errorNotificationKey', '$state', 'MAX_SYSTEM_NOTIFICATION_TITLE_LENGTH'
+        'errorNotificationKey', '$state', 'MAX_SYSTEM_NOTIFICATION_TITLE_LENGTH', 'systemNotificationService'
     ];
 
     function adminSystemNotificationEditController(systemNotification, author, FunctionDecorator,
                                                    SystemNotificationResource, successNotificationKey,
                                                    errorNotificationKey, $state,
-                                                   MAX_SYSTEM_NOTIFICATION_TITLE_LENGTH) {
+                                                   MAX_SYSTEM_NOTIFICATION_TITLE_LENGTH,
+                                                   systemNotificationService) {
         var vm = this;
 
         vm.$onInit = onInit;
@@ -108,6 +109,7 @@
                 new SystemNotificationResource().create(systemNotification);
 
             return promise.then(function() {
+                systemNotificationService.clearCachedSystemNotifications();
                 $state.go('.^', {}, {
                     reload: true
                 });

--- a/src/admin-system-notification-edit/admin-system-notification-edit.controller.spec.js
+++ b/src/admin-system-notification-edit/admin-system-notification-edit.controller.spec.js
@@ -30,6 +30,7 @@ describe('AdminSystemNotificationEditController', function() {
             this.$q = $injector.get('$q');
             this.$rootScope = $injector.get('$rootScope');
             this.$state = $injector.get('$state');
+            this.systemNotificationService = $injector.get('systemNotificationService');
         });
 
         this.author = new this.UserDataBuilder().buildReferenceDataUserJson();
@@ -40,6 +41,7 @@ describe('AdminSystemNotificationEditController', function() {
         spyOn(this.SystemNotificationResource.prototype, 'create').andReturn(this.$q.resolve(this.systemNotification));
         spyOn(this.SystemNotificationResource.prototype, 'update').andReturn(this.$q.resolve(this.systemNotification));
         spyOn(this.$state, 'go').andReturn();
+        spyOn(this.systemNotificationService, 'clearCachedSystemNotifications');
 
         this.initController = function() {
             this.vm = this.$controller('AdminSystemNotificationEditController', {
@@ -126,6 +128,23 @@ describe('AdminSystemNotificationEditController', function() {
             expect(this.$state.go).toHaveBeenCalledWith('.^', {}, {
                 reload: true
             });
+        });
+
+        it('should clear the cached system notifications on success', function() {
+            this.initController();
+            this.vm.saveSystemNotification();
+            this.$rootScope.$apply();
+
+            expect(this.systemNotificationService.clearCachedSystemNotifications).toHaveBeenCalled();
+        });
+
+        it('should not clear the cached system notifications when saving fails', function() {
+            this.SystemNotificationResource.prototype.update.andReturn(this.$q.reject());
+            this.initController();
+            this.vm.saveSystemNotification();
+            this.$rootScope.$apply();
+
+            expect(this.systemNotificationService.clearCachedSystemNotifications).not.toHaveBeenCalled();
         });
 
     });

--- a/src/openlmis-home/home.routes.spec.js
+++ b/src/openlmis-home/home.routes.spec.js
@@ -47,6 +47,7 @@ describe('openlmis.home route', function() {
                         .withLastName('Admin')
                         .build()
                 )
+                .withoutExpiryDate()
                 .build(),
             new this.SystemNotificationDataBuilder()
                 .withAuthor(
@@ -54,6 +55,7 @@ describe('openlmis.home route', function() {
                         .withId(this.users[1].id)
                         .build()
                 )
+                .withoutExpiryDate()
                 .build(),
             new this.SystemNotificationDataBuilder()
                 .withAuthor(
@@ -61,6 +63,7 @@ describe('openlmis.home route', function() {
                         .withId(this.users[1].id)
                         .build()
                 )
+                .withoutExpiryDate()
                 .build(),
             new this.SystemNotificationDataBuilder()
                 .withAuthor(
@@ -68,6 +71,7 @@ describe('openlmis.home route', function() {
                         .withId(this.users[0].id)
                         .build()
                 )
+                .withoutExpiryDate()
                 .build()
         ];
 

--- a/src/referencedata-system-notification/system-notification.service.js
+++ b/src/referencedata-system-notification/system-notification.service.js
@@ -47,31 +47,61 @@
          * @name getSystemNotifications
          *
          * @description
-         * Retrieves notifications and saves them in the local storage.
+         * Retrieves notifications and saves them in the local storage. The cached list is
+         * filtered by the current active window on every call, so notifications that have
+         * expired (or are not yet active) since they were cached stop being returned without
+         * requiring the user to log in again.
          *
-         * @return {Object}        Array of system notifications
+         * @return {Object}        Array of currently displayed system notifications
          */
         function getSystemNotifications() {
-            if (systemNotificationsPromise) {
-                return systemNotificationsPromise;
+            if (!systemNotificationsPromise) {
+                var cachedNotifications = localStorageService.get(SYSTEM_NOTIFICATIONS);
+
+                if (cachedNotifications && cachedNotifications.length) {
+                    systemNotificationsPromise = $q.resolve(angular.fromJson(cachedNotifications));
+                } else {
+                    systemNotificationsPromise = new SystemNotificationResource().query({
+                        isDisplayed: true,
+                        expand: 'author'
+                    })
+                        .then(function(systemNotifications) {
+                            cacheSystemNotification(systemNotifications);
+                            return systemNotifications.content;
+                        });
+                }
             }
 
-            var cachedNotifications = localStorageService.get(SYSTEM_NOTIFICATIONS);
+            return systemNotificationsPromise.then(function(notifications) {
+                return notifications.filter(isCurrentlyDisplayed);
+            });
+        }
 
-            if (cachedNotifications && cachedNotifications.length) {
-                systemNotificationsPromise = $q.resolve(angular.fromJson(cachedNotifications));
-            } else {
-                systemNotificationsPromise = new SystemNotificationResource().query({
-                    isDisplayed: true,
-                    expand: 'author'
-                })
-                    .then(function(systemNotifications) {
-                        cacheSystemNotification(systemNotifications);
-                        return $q.resolve(systemNotifications.content);
-                    });
+        /**
+         * @ngdoc method
+         * @methodOf systemNotification.systemNotificationService
+         * @name isCurrentlyDisplayed
+         *
+         * @description
+         * Decides whether a system notification should be displayed at the current moment.
+         * Mirrors the server-side rule used by the referencedata service when querying with
+         * isDisplayed=true: the notification must be active and the current time must fall
+         * within its (inclusive) start/expiry window. A missing start or expiry date means
+         * that boundary is open-ended.
+         *
+         * @param  {Object}  notification  the system notification to check
+         * @return {Boolean}               true if the notification should currently be shown
+         */
+        function isCurrentlyDisplayed(notification) {
+            if (!notification.active) {
+                return false;
             }
 
-            return systemNotificationsPromise;
+            var now = new Date();
+            var hasStarted = !notification.startDate || new Date(notification.startDate) <= now;
+            var notExpired = !notification.expiryDate || new Date(notification.expiryDate) >= now;
+
+            return hasStarted && notExpired;
         }
 
         /**

--- a/src/referencedata-system-notification/system-notification.service.spec.js
+++ b/src/referencedata-system-notification/system-notification.service.spec.js
@@ -32,8 +32,12 @@ describe('systemNotificationService', function() {
         this.localStorageKey = 'systemNotifications';
 
         this.systemNotifications = [
-            new this.SystemNotificationDataBuilder().build(),
-            new this.SystemNotificationDataBuilder().build()
+            new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .build(),
+            new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .build()
         ];
 
         this.systemNotificationsPage = new this.PageDataBuilder()
@@ -97,6 +101,80 @@ describe('systemNotificationService', function() {
             this.$rootScope.$apply();
 
             expect(rejected).toEqual(true);
+        });
+
+        it('should not return inactive notifications', function() {
+            var active = new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .build();
+            var inactive = new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .inactive()
+                .build();
+
+            this.SystemNotificationResource.prototype.query.andReturn(this.$q.resolve(
+                new this.PageDataBuilder()
+                    .withContent([active, inactive])
+                    .build()
+            ));
+
+            var result;
+            this.systemNotificationService.getSystemNotifications()
+                .then(function(notifications) {
+                    result = notifications;
+                });
+            this.$rootScope.$apply();
+
+            expect(result).toEqual([active]);
+        });
+
+        it('should not return notifications that have already expired', function() {
+            var displayed = new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .build();
+            var expired = new this.SystemNotificationDataBuilder()
+                .withExpiryDate('2000-01-01T00:00:00.000Z')
+                .build();
+
+            this.SystemNotificationResource.prototype.query.andReturn(this.$q.resolve(
+                new this.PageDataBuilder()
+                    .withContent([displayed, expired])
+                    .build()
+            ));
+
+            var result;
+            this.systemNotificationService.getSystemNotifications()
+                .then(function(notifications) {
+                    result = notifications;
+                });
+            this.$rootScope.$apply();
+
+            expect(result).toEqual([displayed]);
+        });
+
+        it('should not return notifications that have not started yet', function() {
+            var displayed = new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .build();
+            var notStarted = new this.SystemNotificationDataBuilder()
+                .withoutExpiryDate()
+                .withStartDate('2999-01-01T00:00:00.000Z')
+                .build();
+
+            this.SystemNotificationResource.prototype.query.andReturn(this.$q.resolve(
+                new this.PageDataBuilder()
+                    .withContent([displayed, notStarted])
+                    .build()
+            ));
+
+            var result;
+            this.systemNotificationService.getSystemNotifications()
+                .then(function(notifications) {
+                    result = notifications;
+                });
+            this.$rootScope.$apply();
+
+            expect(result).toEqual([displayed]);
         });
 
     });


### PR DESCRIPTION
## Summary

System notifications did not refresh during a session:

- a **newly added** notification did not appear, and the corner indicator kept
  saying *"No System Notifications"*, until a full page refresh;
- an **expired** notification kept showing until the user logged out and back in.

This PR makes the home page banner and the corner indicator update without a
page reload or a re-login.

Jira: [OLMIS-7247](https://openlmis.atlassian.net/browse/OLMIS-7247)

## Root cause

`systemNotificationService` caches notifications in `localStorage` and memoizes
the fetch. Two independent problems:

1. **New/edited notification not shown** — `AdminSystemNotificationEditController`
   saved via create/update and only did `$state.go(reload)`; it never cleared the
   cache, so the stale list survived and the indicator/banner did not update.
2. **Expired notification kept showing** — the cache was cleared only on login
   (`registerPostLoginAction`), and `getSystemNotifications()` never re-evaluated
   the active window, so an expired notification stayed cached (even across a hard
   refresh) until re-login.

## Changes

Frontend only. Two commits:

**1. Clear cache after create/update** — fixes symptom 1
- `admin-system-notification-edit.controller.js` — call
  `clearCachedSystemNotifications()` after a successful save
- `admin-system-notification-edit.controller.spec.js`

**2. Filter expired/inactive notifications on read** — fixes symptom 2
- `system-notification.service.js` — cache the fetched list, but filter it by the
  current active window on every read (`isCurrentlyDisplayed`)
- `system-notification.service.spec.js`
- `home.routes.spec.js` — adjusted fixtures to non-expired notifications
- `CHANGELOG.md`

### Backend alignment
The client-side filter mirrors the referencedata `isDisplayed=true` rule
(`SystemNotificationRepositoryImpl`): a notification is shown when it is **active**
and now is within its **inclusive** window (`startDate <= now <= expiryDate`); a
missing start or expiry date leaves that boundary open.

## Testing

- [x] Unit tests green — `openlmis-referencedata-ui` 2374/2374, full `reference-ui`
  build 4504/4504
- [x] New cases: cache cleared on save (and not on failure); inactive / expired /
  not-yet-started notifications filtered out
- [x] Manual verification on a local `reference-ui` build (frontend local, backend UAT)

## Verification

<!-- Drag the 5 verification screenshots here, in order -->

1. Home before adding — indicator "No System Notifications".
2. Adding a notification (Active, start = yesterday, expiry = a few minutes ahead).
3. Notification saved — appears in Administration → System Notifications.
4. Home right after navigating via the menu (no manual refresh) — indicator shows
   "System Notifications (1)", banner displayed. ✅ Symptom 1 fixed.
5. Home after expiry + a normal refresh, still logged in — notification gone,
   indicator back to "No System Notifications". ✅ Symptom 2 fixed.

## Acceptance criteria

- [x] System notifications on the home page and the top-right indicator work
  correctly, without a page refresh or a re-login.

[OLMIS-7247]: https://openlmis.atlassian.net/browse/OLMIS-7247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ