### PR TITLE
OLMIS-7247: Refresh system notifications indicator on navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Bug fixes:
 * [OLMIS-7247](https://openlmis.atlassian.net/browse/OLMIS-7247): Fixed system notifications not refreshing without re-login.
   * Clear the cached notifications after creating/editing a notification so the home page banner and indicator update immediately.
   * Filter the cached list by the current active window on every read so expired or deactivated notifications stop being displayed without logging out.
+  * Refresh the notifications indicator on navigation so its count stays consistent with the home page (an expired notification stops being counted without a reload).
 
 5.6.19 / 2026-06-09
 ==================

--- a/src/openlmis-system-notifications-indicator/openlmis-system-notifications-indicator.controller.js
+++ b/src/openlmis-system-notifications-indicator/openlmis-system-notifications-indicator.controller.js
@@ -28,15 +28,24 @@
         .module('openlmis-system-notifications-indicator')
         .controller('SystemNotificationsIndicatorController', controller);
 
-    controller.$inject = ['offlineService', 'systemNotificationService'];
+    controller.$inject = ['offlineService', 'systemNotificationService', '$rootScope'];
 
-    function controller(offlineService, systemNotificationService) {
+    function controller(offlineService, systemNotificationService, $rootScope) {
 
         var vm = this;
 
         vm.$onInit = onInit;
 
         function onInit() {
+            refreshSystemNotifications();
+
+            // Re-read the notifications on every navigation so the indicator stays consistent
+            // with the home page - notifications that expired during the session stop being
+            // counted without requiring a full page reload or re-login.
+            $rootScope.$on('$stateChangeSuccess', refreshSystemNotifications);
+        }
+
+        function refreshSystemNotifications() {
             if (!offlineService.isOffline()) {
                 return systemNotificationService.getSystemNotifications()
                     .then(function(results) {

--- a/src/openlmis-system-notifications-indicator/openlmis-system-notifications-indicator.controller.spec.js
+++ b/src/openlmis-system-notifications-indicator/openlmis-system-notifications-indicator.controller.spec.js
@@ -91,4 +91,42 @@ describe('SystemNotificationsIndicatorController', function() {
 
     });
 
+    describe('on state change', function() {
+
+        it('should re-read system notifications after navigation', function() {
+            this.$rootScope.$apply();
+            this.systemNotificationService.getSystemNotifications.reset();
+
+            this.$rootScope.$broadcast('$stateChangeSuccess');
+            this.$rootScope.$apply();
+
+            expect(this.systemNotificationService.getSystemNotifications).toHaveBeenCalled();
+        });
+
+        it('should update the exposed notifications after navigation', function() {
+            this.$rootScope.$apply();
+
+            var refreshed = [this.systemNotifications[0]];
+            this.systemNotificationService.getSystemNotifications
+                .andReturn(this.$q.resolve(refreshed));
+
+            this.$rootScope.$broadcast('$stateChangeSuccess');
+            this.$rootScope.$apply();
+
+            expect(this.vm.systemNotifications).toEqual(refreshed);
+        });
+
+        it('should not re-read system notifications while offline', function() {
+            this.$rootScope.$apply();
+            this.systemNotificationService.getSystemNotifications.reset();
+            this.offlineService.isOffline.andReturn(true);
+
+            this.$rootScope.$broadcast('$stateChangeSuccess');
+            this.$rootScope.$apply();
+
+            expect(this.systemNotificationService.getSystemNotifications).not.toHaveBeenCalled();
+        });
+
+    });
+
 });


### PR DESCRIPTION
The indicator only fetched notifications on init, so after a notification expired during the session its count stayed stale (e.g. showed "1" while the home page correctly showed none) until a full page reload or re-login.

Re-read the notifications on every $stateChangeSuccess so the indicator's count stays consistent with the home page. getSystemNotifications() already filters out expired/inactive notifications on each call, so this keeps the count current with no extra backend requests (the cached promise is reused).