### PR TITLE
OPSD-107: Show cancelled orders in the home page order info panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Bug fixes:
   * Filter the cached list by the current active window on every read so expired or deactivated notifications stop being displayed without logging out.
   * Refresh the notifications indicator on navigation so its count stays consistent with the home page (an expired notification stops being counted without a reload).
 
+Improvements:
+* [OPSD-107](https://openlmis.atlassian.net/browse/OPSD-107): Show cancelled orders in the home page order info panel.
+
 5.6.19 / 2026-06-09
 ==================
 Improvements:

--- a/src/openlmis-home-alerts-panel/messages_en.json
+++ b/src/openlmis-home-alerts-panel/messages_en.json
@@ -18,5 +18,6 @@
     "orders.status.SHIPPED": "Shipped",
     "orders.status.IN_ROUTE": "In Route",
     "orders.status.RECEIVED": "Received",
-    "orders.status.TRANSFER_FAILED": "Transfer Failed"
+    "orders.status.TRANSFER_FAILED": "Transfer Failed",
+    "orders.status.CANCELLED": "Cancelled"
 }

--- a/src/openlmis-home-alerts-panel/openlmis-home-alerts-panel.service.js
+++ b/src/openlmis-home-alerts-panel/openlmis-home-alerts-panel.service.js
@@ -63,7 +63,7 @@
             ];
             var orderOrder = [
                 'CREATING', 'ORDERED', 'FULFILLING', 'READY_TO_PACK',
-                'SHIPPED', 'IN_ROUTE', 'RECEIVED', 'TRANSFER_FAILED'
+                'SHIPPED', 'IN_ROUTE', 'RECEIVED', 'TRANSFER_FAILED', 'CANCELLED'
             ];
 
             var order = tableName === 'requisition' ? requisitionOrder : orderOrder;


### PR DESCRIPTION
[OPSD-107](https://openlmis.atlassian.net/browse/OPSD-107)

The home page order info panel wasn't showing cancelled orders. The backend already returns a count for every status (CANCELLED was added in OPSD-45), but the panel runs those counts through a hardcoded list of statuses to display and CANCELLED wasn't in it, so the count got dropped.

Changes:
- Added `CANCELLED` to the order status list in `openlmis-home-alerts-panel.service.js`
- Added the `orders.status.CANCELLED` translation label
- CHANGELOG

Frontend only, no backend change. Left CANCELLED out of the "important" highlight list since a cancelled order isn't something that needs attention.

The backend `/api/orders/statusesStatsData` already includes the CANCELLED count, so once the panel is rebuilt it lists cancelled orders alongside the other statuses.


[OPSD-107]: https://openlmis.atlassian.net/browse/OPSD-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ