### PR TITLE
OLMIS-8294: Pass sonar.projectVersion via scanner args instead of editing the properties file

### DIFF
--- a/.github/workflows/sonar-analysis.yml
+++ b/.github/workflows/sonar-analysis.yml
@@ -23,10 +23,12 @@ jobs:
           mkdir -p build/sonar
           cp build/test/coverage/*/lcov.info build/sonar/lcov.info
           sed -i 's#/app/\.tmp/javascript/src/#src/#g; s#\.tmp/javascript/src/#src/#g' build/sonar/lcov.info
-      - name: Set Sonar project version
-        run: echo "sonar.projectVersion=$(grep '^version=' project.properties | cut -d= -f2)" >> sonar-project.properties
+      - name: Read project version
+        run: echo "PROJECT_VERSION=$(grep '^version=' project.properties | cut -d= -f2)" >> "$GITHUB_ENV"
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: -Dsonar.projectVersion=${{ env.PROJECT_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug fixes:
   * Filter the cached list by the current active window on every read so expired or deactivated notifications stop being displayed without logging out.
   * Refresh the notifications indicator on navigation so its count stays consistent with the home page (an expired notification stops being counted without a reload).
 * [OLMIS-8191](https://openlmis.atlassian.net/browse/OLMIS-8191): Wrap long read-only text in admin lists — the System Notifications message (previously cropped), and Role/Product/Processing period descriptions.
+* [OLMIS-8294](https://openlmis.atlassian.net/browse/OLMIS-8294): Fixed SonarCloud not picking up unit-test coverage. Pass sonar.projectVersion to the scanner through its args instead of appending it to sonar-project.properties during the build, so a missing trailing newline can no longer glue it onto the lcov report-path line and zero out coverage.
 
 Improvements:
 * SonarCloud now receives JS unit-test coverage (lcov) so the quality gate reflects real coverage on new code.


### PR DESCRIPTION
### Problem

The `Set Sonar project version` step wrote the version into `sonar-project.properties` during the build:

```
echo "sonar.projectVersion=$(grep '^version=' project.properties | cut -d= -f2)" >> sonar-project.properties
```

When the file has no trailing newline, the append glues onto the last line:

```
sonar.javascript.lcov.reportPaths=build/sonar/lcov.infosonar.projectVersion=5.6.20-SNAPSHOT
```

The scanner then logs `No LCOV files were found using build/sonar/lcov.info...` and coverage reads as 0% on new code, which fails the quality gate. The build stays green, so it is easy to miss. Coverage history for this project shows 70.7% on 2026-07-27, then 0.0% right after the projectVersion step landed on 07-29.

### Fix

Stop editing the committed file at build time. Read the version into an env var and pass it straight to the scanner via the action's `args` input:

```
- name: Read project version
  run: echo "PROJECT_VERSION=$(grep '^version=' project.properties | cut -d= -f2)" >> "$GITHUB_ENV"
- name: SonarCloud Scan
  uses: SonarSource/sonarcloud-github-action@master
  with:
    args: -Dsonar.projectVersion=${{ env.PROJECT_VERSION }}
```

This is the same approach the backend services already use (they pass `-Dsonar.projectVersion` to the scanner rather than editing a file), which is why they were never affected. With this change a missing trailing newline can no longer break coverage.

### Scope

Three FE repos hit this: referencedata-ui, report-ui, fulfillment-ui. This PR is the pilot on referencedata-ui. Once the approach looks good here, the same workflow change goes to the other FE repos that still edit the file.
